### PR TITLE
Remove 'rvm: system' from the TravisCI config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 dist: xenial
 language: ruby
-rvm: system
 
 branches:
   only:


### PR DESCRIPTION
We originally did this because RVM's Ruby and Chef-DK's Ruby were interfering
with each other, but now Travis has a 'gem install bundler' step that's failing
because the travis user doesn't have write permissions on the system Ruby.